### PR TITLE
Added support for a gem local mediainfo binary.

### DIFF
--- a/lib/mediainfo.rb
+++ b/lib/mediainfo.rb
@@ -439,8 +439,17 @@ class Mediainfo
   
   def path; self.class.path; end
   def xml_parser; self.class.xml_parser; end
-  
-  def self.default_mediainfo_path!; self.path = "mediainfo"; end
+
+  def self.default_mediainfo_path!
+    self.path = default_mediainfo_path
+  end
+
+  def self.default_mediainfo_path
+    local_bin_path = File.expand_path File.join('../../', 'ext', 'mediainfo'), __FILE__
+
+    File.exists?(local_bin_path) ? local_bin_path : "mediainfo"
+  end
+
   default_mediainfo_path! unless path
   
   def mediainfo_version; self.class.version; end

--- a/test/mediainfo_test.rb
+++ b/test/mediainfo_test.rb
@@ -113,17 +113,17 @@ class MediainfoTest < ActiveSupport::TestCase
   test "retains last system command generated" do
     p = File.expand_path "./test/fixtures/dinner.3g2.xml"
     m = Mediainfo.new p
-    assert_equal "mediainfo \"#{p}\" --Output=XML", m.last_command
+    assert_equal "#{Mediainfo.path} \"#{p}\" --Output=XML", m.last_command
   end
   
   test "allows customization of path to mediainfo binary" do
     Mediainfo.any_instance.stubs(:run_command!).returns("test")
-    
-    assert_equal "mediainfo", Mediainfo.path
-    
+
+    assert_equal Mediainfo.default_mediainfo_path, Mediainfo.path
+
     m = Mediainfo.new "/dev/null"
-    assert_equal "mediainfo \"/dev/null\" --Output=XML", m.last_command
-    
+    assert_equal "#{Mediainfo.default_mediainfo_path} \"/dev/null\" --Output=XML", m.last_command
+
     Mediainfo.any_instance.stubs(:mediainfo_version).returns("0.7.25")
     
     Mediainfo.path = "/opt/local/bin/mediainfo"


### PR DESCRIPTION
If the mediainfo binary exists at GEM_ROOT/ext/mediainfo, it will be used as the default unless overridden.
