### PR TITLE
add base support of Mediainfo OtherStream

### DIFF
--- a/lib/mediainfo.rb
+++ b/lib/mediainfo.rb
@@ -362,10 +362,8 @@ class Mediainfo
     mediainfo_int_reader :delay
   end
 
-
   class OtherStream < Stream
   end
-
 
   Mediainfo::SECTIONS.each do |stream_type|
     class_eval %{

--- a/lib/mediainfo.rb
+++ b/lib/mediainfo.rb
@@ -112,7 +112,7 @@ class Mediainfo
   # AttrReaders depends on this.
   def self.supported_attributes; @supported_attributes ||= []; end
   
-  SECTIONS             = [:general, :video, :audio, :image, :menu, :text]
+  SECTIONS             = [:general, :video, :audio, :image, :menu, :text, :other]
   NON_GENERAL_SECTIONS = SECTIONS - [:general]
   
   attr_reader :streams
@@ -361,7 +361,12 @@ class Mediainfo
     mediainfo_date_reader :tagged_date
     mediainfo_int_reader :delay
   end
-  
+
+
+  class OtherStream < Stream
+  end
+
+
   Mediainfo::SECTIONS.each do |stream_type|
     class_eval %{
       def #{stream_type}; @#{stream_type}_proxy ||= StreamProxy.new(self, :#{stream_type}); end


### PR DESCRIPTION
Fix Error 'Uncaught exception: bad stream type: "Other"'
May influence issue #3 
