### PR TITLE
Set up mocha correctly for mocha >= 0.9.8

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,6 +2,7 @@ require "test/unit"
 
 require "rubygems"
 require "mocha"
+require "mocha/test_unit"
 begin; require "redgreen"; rescue LoadError; end
 
 module ActiveSupport


### PR DESCRIPTION
As of Mocha 0.9.8 test/unit support is no longer automatically
installed and needs to be installed with an extra call.