### PR TITLE
AWS S3 URL support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ MediaInfo is a class wrapping [the mediainfo CLI](http://mediainfo.sourceforge.n
 
 ## Usage
 
+- Versions > 1.3.0 support S3 URLs. See rspec test for example of how to obtain the supported URL.
+
 #### Parsing raw XML
     media_info = MediaInfo.from(File.open('iphone6+_video.mov.xml').read)
 #### Handling a local file

--- a/lib/mediainfo/version.rb
+++ b/lib/mediainfo/version.rb
@@ -1,3 +1,3 @@
 module MediaInfo
-  VERSION = '1.2.2'
+  VERSION = '1.3.0'
 end


### PR DESCRIPTION
- Supports AWS S3 urls now (see test example)
- Better error reporting
- Removal of https url tests since S3 url is https (got test time down to 20 seconds)