### PR TITLE
Quick fix for S3 URL error reporting logic

### DIFF
--- a/lib/mediainfo.rb
+++ b/lib/mediainfo.rb
@@ -90,7 +90,7 @@ module MediaInfo
     raise ArgumentError, 'Your input cannot be blank.' if input.nil?
     command = "#{location} '#{input}' --Output=XML"
     raw_response, errors, status = Open3.capture3(command)
-    unless errors.empty? && status.exitstatus == 0
+    unless status.exitstatus == 0
       raise ExecutionError, "Execution of '#{command}' failed: \n #{errors.red}"
     end
     return raw_response

--- a/lib/mediainfo/version.rb
+++ b/lib/mediainfo/version.rb
@@ -1,3 +1,3 @@
 module MediaInfo
-  VERSION = '1.3.0'
+  VERSION = '1.3.1'
 end

--- a/spec/spec_shared_examples.rb
+++ b/spec/spec_shared_examples.rb
@@ -52,13 +52,20 @@ RSpec.shared_examples 'expected from class method for a url' do
     it 'returns an instance of MediaInfo::Tracks' do
       region = 'us-east-2'
       bucket = 'github-mediainfo'
-      object_key = 'small.mp4'
-      s3_resource = Aws::S3::Resource.new(        
+      object_key = 'SampleVideo_1280x720_50mb.mp4'
+      s3_resource = Aws::S3::Resource.new(
         region: region,
         access_key_id: ENV['AWS_ACCESS_KEY_ID'],
         secret_access_key: ENV['AWS_SECRET_ACCESS_KEY']
       )
+      # presigner = Aws::S3::Presigner.new(client: Aws::S3::Client.new(
+      #   region: region,
+      #   access_key_id: ENV['AWS_ACCESS_KEY_ID'],
+      #   secret_access_key: ENV['AWS_SECRET_ACCESS_KEY']
+      # ))
+      # presigner.presigned_url(:get_object, bucket: bucket, key: object_key)
       signed_url = s3_resource.bucket(bucket).object(object_key).presigned_url(:get, expires_in: 3600)
+      # signed_url = s3_resource.bucket(bucket).object(object_key).public_url
       expect(MediaInfo.from(signed_url)).to be_an_instance_of(MediaInfo::Tracks)
     end
   end


### PR DESCRIPTION
I shouldn't be checking if the STDERR is empty or not to raise a failure. If the status code is 0, it's fine and whatever we see -- like `HTTP server doesn't seem to support byte ranges. Cannot resume.` -- is fine.