### PR TITLE
Fix an issue with unescaped characters in paths

### DIFF
--- a/lib/mediainfo.rb
+++ b/lib/mediainfo.rb
@@ -89,7 +89,7 @@ module MediaInfo
 
   def self.run(input = nil)
     raise ArgumentError, 'Your input cannot be blank.' if input.nil?
-    command = "#{location} '#{input}' --Output=XML"
+    command = "#{location} \"#{input}\" --Output=XML"
     raw_response, errors, status = Open3.capture3(command)
     unless status.exitstatus == 0
       raise ExecutionError, "Execution of '#{command}' failed: \n #{errors.red}"


### PR DESCRIPTION
Without this `MediaInfo.run("/foo/bar's")` fails.