### PR TITLE
Fix time zone parsing for "*_Date" attributes (#52)

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,18 @@ Sometimes you'll have more than one track of a given type:
 - Any track attribute name with "date" and matching /\d-/ will be converted using Time.parse:
 
 
-        media_info.video.encoded_date => 2018-03-30 12:12:08 -0400
-        media_info.video.customdate   => 2016-02-10 01:00:00 -0600
+        media_info.video.encoded_date => 2018-03-30 12:12:08 UTC
+        media_info.video.customdate   => 2016-02-10 01:00:00 UTC
+
+  > 🕑 **A note on time zones:**
+  > Whenever possible, mediainfo provides timestamps in UTC.
+  > To convert UTC timestamps to your system time zone, use `#getlocal`:
+  >
+  >     media_info.video.encoded_date.getlocal => 2018-03-30 05:12:08 -0700
+  >
+  > If a `*date` attribute is already in your local time zone,
+  > that means no time zone data was found,
+  > and the given time zone may not be correct.
 
 - .duration and .overall_duration will be returned as milliseconds AS LONG AS the Duration and Overall_Duration match one of the expected units (each separated by a space or not):
     - h (\<Duration>15h\</Duration>) (hour)

--- a/lib/mediainfo/tracks.rb
+++ b/lib/mediainfo/tracks.rb
@@ -109,7 +109,7 @@ module MediaInfo
           return value.to_f
         elsif name.downcase.include?('date') && !value.match(/\d-/).nil?
           # Dates
-          return Time.parse(value)
+          return Time.parse(value.sub(/^UTC\s+(.*)$/, '\1 UTC'))
         end
 
         value

--- a/spec/mediainfo_tracks_spec.rb
+++ b/spec/mediainfo_tracks_spec.rb
@@ -114,4 +114,37 @@ RSpec.describe MediaInfo::Tracks do
 
   end
 
+  describe '#encoded_date attribute' do
+    let(:xml_data) { xml_files_content[:trailing_zero] }
+    let(:timestamp) { Time.new(2018, 3, 30, 12, 12, 8, 'UTC') }
+
+    context 'when the chosen parser (MEDIAINFO_XML_PARSER) is the default one' do
+      context 'for UTC timestamps' do
+        it 'applies the UTC time zone' do
+          expect(MediaInfo.from(xml_data).general.encoded_date)
+            .to eq(timestamp).and be_utc
+        end
+      end
+
+      context 'for zoneless timestamps' do
+        it 'applies the local system time zone'
+      end
+    end
+
+    context 'when the chosen parser (MEDIAINFO_XML_PARSER) is nokogiri' do
+      include_context 'sets MEDIAINFO_XML_PARSER to nokogiri'
+
+      context 'for UTC timestamps' do
+        it 'applies the UTC time zone' do
+          expect(MediaInfo.from(xml_data).general.encoded_date)
+            .to eq(timestamp).and be_utc
+        end
+      end
+
+      context 'for zoneless timestamps' do
+        it 'applies the local system time zone'
+      end
+    end
+  end
+
 end

--- a/spec/mediainfo_tracks_spec.rb
+++ b/spec/mediainfo_tracks_spec.rb
@@ -125,10 +125,6 @@ RSpec.describe MediaInfo::Tracks do
             .to eq(timestamp).and be_utc
         end
       end
-
-      context 'for zoneless timestamps' do
-        it 'applies the local system time zone'
-      end
     end
 
     context 'when the chosen parser (MEDIAINFO_XML_PARSER) is nokogiri' do
@@ -139,10 +135,6 @@ RSpec.describe MediaInfo::Tracks do
           expect(MediaInfo.from(xml_data).general.encoded_date)
             .to eq(timestamp).and be_utc
         end
-      end
-
-      context 'for zoneless timestamps' do
-        it 'applies the local system time zone'
       end
     end
   end


### PR DESCRIPTION
Prior to this commit,
this library would apply the local system time zone to UTC timestamps.

For instance,

    <Encoded_Date>UTC 2018-03-30 12:12:08</Encoded_Date>

would produce

    >> MediaInfo.from(file).video.encoded_date
    => 2018-03-30 12:12:08 -0700

This commit addresses this problem
by moving the "UTC" prefix to the end of the string before parsing it.