### PR TITLE
Remove URI.escape and add ruby 3 rexml dependency

### DIFF
--- a/lib/mediainfo.rb
+++ b/lib/mediainfo.rb
@@ -106,7 +106,7 @@ module MediaInfo
       http.use_ssl = true if input.is_a? URI::HTTPS # For https support
       http_request = http.request(request)
       raise RemoteUrlError, "HTTP call to #{input} is not working : #{http_request.value}" unless http_request.is_a?(Net::HTTPOK)
-      MediaInfo::Tracks.new(MediaInfo.run(URI.escape(input.to_s)))
+      MediaInfo::Tracks.new(MediaInfo.run(input.to_s))
     end
   end
 

--- a/mediainfo.gemspec
+++ b/mediainfo.gemspec
@@ -19,7 +19,8 @@ Gem::Specification.new do |s|
     f.match(%r{^(test|spec|features)/})
   end
 
-  # Since Ruby 1.8, REXML is included in the standard Ruby distribution.
+  s.add_dependency 'rexml'
+
   s.add_development_dependency 'bundler', '~> 2'
   s.add_development_dependency 'rake', '~> 12.3'
   s.add_development_dependency 'rspec', '~> 3.0'


### PR DESCRIPTION
Hi! I'm not sure this is how you wanted to handle this, but I noted the TODO in the readme about this, and wanted to get this gem working on ruby 3.0.

I can't seem to even create a URI object with unescaped components, and there didn't seem to be a test for it that broke from this change.
<details>
<summary>Here are my failed attempts</summary>

```ruby
irb(main):001:0> a = URI("https://example.com/what now/oh boy.html?umm=blep okay")
/Users/markoleson/.rbenv/versions/3.0.1/lib/ruby/3.0.0/uri/rfc3986_parser.rb:67:in `split': bad URI(is not URI?): "https://example.com/what now/oh boy.html?umm=blep okay" (URI::InvalidURIError)
	from /Users/markoleson/.rbenv/versions/3.0.1/lib/ruby/3.0.0/uri/rfc3986_parser.rb:72:in `parse'
	from /Users/markoleson/.rbenv/versions/3.0.1/lib/ruby/3.0.0/uri/common.rb:171:in `parse'
	from /Users/markoleson/.rbenv/versions/3.0.1/lib/ruby/3.0.0/uri/common.rb:674:in `URI'
	from (irb):1:in `<main>'
	from /Users/markoleson/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/irb-1.3.5/exe/irb:11:in `<top (required)>'
	from /Users/markoleson/.rbenv/versions/3.0.1/bin/irb:23:in `load'
	from /Users/markoleson/.rbenv/versions/3.0.1/bin/irb:23:in `<main>'
irb(main):002:0> a = URI("https://example.com/what%20now/oh%20boy.html?umm=blep%20okay")
=> #<URI::HTTPS https://example.com/what%20now/oh%20boy.html?umm=blep%20okay>
irb(main):003:0> a.path = "/what now/oh boy.html"
/Users/markoleson/.rbenv/versions/3.0.1/lib/ruby/3.0.0/uri/generic.rb:760:in `check_path': bad component(expected absolute path component): /what now/oh boy.html (URI::InvalidComponentError)
	from /Users/markoleson/.rbenv/versions/3.0.1/lib/ruby/3.0.0/uri/generic.rb:806:in `path='
	from (irb):3:in `<main>'
	from /Users/markoleson/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/irb-1.3.5/exe/irb:11:in `<top (required)>'
	from /Users/markoleson/.rbenv/versions/3.0.1/bin/irb:23:in `load'
	from /Users/markoleson/.rbenv/versions/3.0.1/bin/irb:23:in `<main>'
irb(main):004:0> URI::HTTPS.build(host: "example.com", path: "/what about this")
/Users/markoleson/.rbenv/versions/3.0.1/lib/ruby/3.0.0/uri/generic.rb:760:in `check_path': bad component(expected absolute path component): /what about this (URI::InvalidComponentError)
	from /Users/markoleson/.rbenv/versions/3.0.1/lib/ruby/3.0.0/uri/generic.rb:806:in `path='
	from /Users/markoleson/.rbenv/versions/3.0.1/lib/ruby/3.0.0/uri/generic.rb:192:in `initialize'
	from /Users/markoleson/.rbenv/versions/3.0.1/lib/ruby/3.0.0/uri/generic.rb:136:in `new'
	from /Users/markoleson/.rbenv/versions/3.0.1/lib/ruby/3.0.0/uri/generic.rb:136:in `build'
	from /Users/markoleson/.rbenv/versions/3.0.1/lib/ruby/3.0.0/uri/http.rb:61:in `build'
	from (irb):4:in `<main>'
	from /Users/markoleson/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/irb-1.3.5/exe/irb:11:in `<top (required)>'
	from /Users/markoleson/.rbenv/versions/3.0.1/bin/irb:23:in `load'
	from /Users/markoleson/.rbenv/versions/3.0.1/bin/irb:23:in `<main>'
```
</details>

Additionally, it seems that the `rexml` dependency must be declared explicitly to work with ruby 3.

Let me know if you want me to take a different direction with this!