### PR TITLE
fix: avoid "literal string will be frozen" warnings

### DIFF
--- a/lib/mediainfo.rb
+++ b/lib/mediainfo.rb
@@ -113,6 +113,7 @@ module MediaInfo
   def self.set_singleton_method(object,name,parameters)
     # Handle parameters with invalid characters (instance_variable_set throws error)
     name.gsub!('.','_') if name.include?('.') ## period in name
+    name.gsub!('-','_') if name.include?('-') ## period in name
     name.downcase!
     # Create singleton_method
     object.instance_variable_set("@#{name}",parameters)

--- a/lib/mediainfo.rb
+++ b/lib/mediainfo.rb
@@ -112,13 +112,13 @@ module MediaInfo
 
   def self.set_singleton_method(object,name,parameters)
     # Handle parameters with invalid characters (instance_variable_set throws error)
-    name.gsub!('.','_') if name.include?('.') ## period in name
-    name.gsub!('-','_') if name.include?('-') ## period in name
-    name.downcase!
+    method_name = name.gsub('.', '_').gsub('-', '_').downcase
+
     # Create singleton_method
-    object.instance_variable_set("@#{name}",parameters)
-    object.define_singleton_method name do
-      object.instance_variable_get "@#{name}"
+    object.instance_variable_set("@#{method_name}",parameters)
+    object.define_singleton_method method_name do
+      object.instance_variable_get "@#{method_name}"
+      object.instance_variable_get "@#{method_name}"
     end
   end
 

--- a/lib/mediainfo/tracks.rb
+++ b/lib/mediainfo/tracks.rb
@@ -23,7 +23,7 @@ module MediaInfo
             track_elements = Attributes.new(track.children.select{ |n| n.is_a? ::Nokogiri::XML::Element }.map{ |parameter|
               parameter.name = standardize_element_name(parameter.name) # Turn various element names into standardized versions (Bit_rate to Bitrate)
               if parameter.text.include?("\n") # if it has children (extra in iphone6+_video.mov.xml)
-                [parameter.name, parameter.children.select { |n| n.is_a? ::Nokogiri::XML::Element }.map{ |parameter| [parameter.name, parameter.text]}]
+                [parameter.name, parameter.children.select { |n| n.is_a? ::Nokogiri::XML::Element }.map{ |parameter| [standardize_element_name(parameter.name), parameter.text]}]
               else
                 [parameter.name, parameter.text]
               end
@@ -68,7 +68,7 @@ module MediaInfo
     # Standardize our Element Names
     ## Relies on valid YAML in lib/attribute_standardization_rules.yml
     def standardize_element_name(name)
-      self.attribute_standardization_rules[name].nil? ? name : self.attribute_standardization_rules[name]
+      self.attribute_standardization_rules[name].nil? ? name.gsub('-', '_') : self.attribute_standardization_rules[name]
     end
 
     class Attributes

--- a/lib/mediainfo/tracks.rb
+++ b/lib/mediainfo/tracks.rb
@@ -23,7 +23,7 @@ module MediaInfo
             track_elements = Attributes.new(track.children.select{ |n| n.is_a? ::Nokogiri::XML::Element }.map{ |parameter|
               parameter.name = standardize_element_name(parameter.name) # Turn various element names into standardized versions (Bit_rate to Bitrate)
               if parameter.text.include?("\n") # if it has children (extra in iphone6+_video.mov.xml)
-                [parameter.name, parameter.children.select { |n| n.is_a? ::Nokogiri::XML::Element }.map{ |parameter| [standardize_element_name(parameter.name), parameter.text]}]
+                [parameter.name, parameter.children.select { |n| n.is_a? ::Nokogiri::XML::Element }.map{ |parameter| [parameter.name, parameter.text]}]
               else
                 [parameter.name, parameter.text]
               end
@@ -68,7 +68,7 @@ module MediaInfo
     # Standardize our Element Names
     ## Relies on valid YAML in lib/attribute_standardization_rules.yml
     def standardize_element_name(name)
-      self.attribute_standardization_rules[name].nil? ? name.gsub('-', '_') : self.attribute_standardization_rules[name]
+      self.attribute_standardization_rules[name].nil? ? name : self.attribute_standardization_rules[name]
     end
 
     class Attributes


### PR DESCRIPTION
[ruby 3.4.0](https://github.com/ruby/ruby/releases/tag/v3_4_0) introduced warnings for string which are not frozen, causing many warnings in our application.

This PR removes the ones in `set_singleton_method`
